### PR TITLE
fix staging schema (ref to old name table)

### DIFF
--- a/hw04/dbt/models/staging/schema.yml
+++ b/hw04/dbt/models/staging/schema.yml
@@ -41,14 +41,14 @@ models:
             description: locationid where the meter was engaged.
             tests:
               - relationships:
-                  to: ref('taxi_zone_lookup')
+                  to: ref('hw04_taxi_zone_lookup')
                   field: locationid
                   severity: warn
           - name: dropoff_locationid 
             description: locationid where the meter was engaged.
             tests:
               - relationships:
-                  to: ref('taxi_zone_lookup')
+                  to: ref('hw04_taxi_zone_lookup')
                   field: locationid
           - name: RateCodeID 
             description: >
@@ -132,14 +132,14 @@ models:
             description: locationid where the meter was engaged.
             tests:
               - relationships:
-                  to: ref('taxi_zone_lookup')
+                  to: ref('hw04_taxi_zone_lookup')
                   field: locationid
                   severity: warn
           - name: dropoff_locationid 
             description: locationid where the meter was engaged.
             tests:
               - relationships:
-                  to: ref('taxi_zone_lookup')
+                  to: ref('hw04_taxi_zone_lookup')
                   field: locationid
                   severity: warn
           - name: RateCodeID 


### PR DESCRIPTION
Остались старые названия taxi_zone_lookup в схеме модели в разделах с тестированием 